### PR TITLE
Fixes Character displays too low on the ground

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -50,7 +50,7 @@ class GameScene extends Phaser.Scene {
             "Collisions Layer",
             this.tileset,
             0,
-            495
+            470
         );
         this.collisionLayer.setVisible(false);
 


### PR DESCRIPTION
Fixes #2 by updating `y` on `createStaticLayer`

<img width="121" alt="Screen Shot 2019-10-01 at 5 25 12 PM" src="https://user-images.githubusercontent.com/17114134/66005597-9abc9b80-e471-11e9-96ec-ab178a0b9707.png">
