### PR TITLE
Fixed the jump animation on the highest point of the jump

### DIFF
--- a/src/sprites/Player.js
+++ b/src/sprites/Player.js
@@ -118,7 +118,7 @@ export default class Player extends Phaser.GameObjects.Sprite {
         }
 
         let anim = null;
-        if (this.body.velocity.y !== 0) {
+        if (this.body.velocity.y !== 0 || this.jumping) {
             anim = "jump";
         } else if (this.body.velocity.x !== 0) {
             anim = "run";


### PR DESCRIPTION
When a jump was done, the animation changed to idle for 1 frame when reaching the highest part. Now it's fixed.